### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/bindings/python/tests/cindex/test_cdb.py
+++ b/bindings/python/tests/cindex/test_cdb.py
@@ -24,7 +24,7 @@ def test_create():
 def test_lookup_fail():
     """Check file lookup failure"""
     cdb = CompilationDatabase.fromDirectory(kInputsDir)
-    assert cdb.getCompileCommands('file_do_not_exist.cpp') == None
+    assert cdb.getCompileCommands('file_do_not_exist.cpp') is None
 
 def test_lookup_succeed():
     """Check we get some results if the file exists in the db"""

--- a/bindings/python/tests/cindex/test_translation_unit.py
+++ b/bindings/python/tests/cindex/test_translation_unit.py
@@ -240,7 +240,7 @@ def test_fail_from_source():
         tu = TranslationUnit.from_source(path)
     except TranslationUnitLoadError:
         tu = None
-    assert tu == None
+    assert tu is None
 
 def test_fail_from_ast_file():
     path = os.path.join(kInputsDir, 'non-existent.ast')
@@ -248,4 +248,4 @@ def test_fail_from_ast_file():
         tu = TranslationUnit.from_ast_file(path)
     except TranslationUnitLoadError:
         tu = None
-    assert tu == None
+    assert tu is None

--- a/bindings/python/tests/cindex/test_type.py
+++ b/bindings/python/tests/cindex/test_type.py
@@ -129,7 +129,7 @@ def test_equal():
     assert a.type == b.type
     assert a.type != v.type
 
-    assert a.type != None
+    assert a.type is not None
     assert a.type != 'foo'
 
 def test_type_spelling():

--- a/tools/clang-format/clang-format-diff.py
+++ b/tools/clang-format/clang-format-diff.py
@@ -69,7 +69,7 @@ def main():
     match = re.search('^\+\+\+\ (.*?/){%s}(\S*)' % args.p, line)
     if match:
       filename = match.group(2)
-    if filename == None:
+    if filename is None:
       continue
 
     if args.regex is not None:

--- a/utils/analyzer/CmpRuns.py
+++ b/utils/analyzer/CmpRuns.py
@@ -145,7 +145,7 @@ class AnalysisRun:
         # reports. Assume that all reports were created using the same
         # clang version (this is always true and is more efficient).
         if 'clang_version' in data:
-            if self.clang_version == None:
+            if self.clang_version is None:
                 self.clang_version = data.pop('clang_version')
             else:
                 data.pop('clang_version')

--- a/utils/check_cfc/obj_diff.py
+++ b/utils/check_cfc/obj_diff.py
@@ -49,7 +49,7 @@ def first_diff(a, b, fromfile, tofile):
             first_diff_idx = idx
             break
 
-    if first_diff_idx == None:
+    if first_diff_idx is None:
         # No difference
         return None
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:swift-clang?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:swift-clang?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
